### PR TITLE
カラーコードクラスを追加

### DIFF
--- a/machico/lib/hex_color.dart
+++ b/machico/lib/hex_color.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class HexColor extends Color {
+  static int _getColorFromHex(String hexColor) {
+    hexColor = hexColor.toUpperCase().replaceAll('#', '');
+    if (hexColor.length == 6) {
+      hexColor = 'FF' + hexColor;
+    }
+    return int.parse(hexColor, radix: 16);
+  }
+
+  HexColor(final String hexColor) : super(_getColorFromHex(hexColor));
+}

--- a/machico/lib/main.dart
+++ b/machico/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'hex_color.dart';
 
 void main() {
   runApp(MyApp());
@@ -51,7 +52,7 @@ class _MyHomePageState extends State<MyHomePage> {
           ],
         ),
       ),
-       // This trailing comma makes auto-formatting nicer for build methods.
+      // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }


### PR DESCRIPTION
## 関連するissue

## 行った変更
- カラーコードを利用できるようHexColorクラスを追加。

## 参考
https://www.it-swarm-ja.tech/ja/function/dart-flutter%E3%81%A7%E5%88%A5%E3%81%AE%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB%E3%81%AE%E6%A9%9F%E8%83%BD%E3%82%92%E4%BD%BF%E7%94%A8%E3%81%99%E3%82%8B%E3%81%AB%E3%81%AF%EF%BC%9F/836104720/
## その他、補足